### PR TITLE
Wechsel von Select zu SelectVariable

### DIFF
--- a/VirtuelleMessstelle/form.json
+++ b/VirtuelleMessstelle/form.json
@@ -1,10 +1,11 @@
 {
     "elements": [
         {
-            "type": "Select",
+            "type": "SelectVariable",
             "caption": "Primary Measuring Point",
             "name": "PrimaryPointID",
-            "width": "700px"
+            "width": "700px",
+            "requiredLogging": 1
         },
         {
             "type": "List",
@@ -39,8 +40,8 @@
                     "width": "auto",
                     "add": 0,
                     "edit": {
-                        "type": "Select",
-                        "width": "700px"
+                        "type": "SelectVariable",
+                        "requiredLogging": 1
                     }
                 }
             ]

--- a/VirtuelleMessstelle/form.json
+++ b/VirtuelleMessstelle/form.json
@@ -4,7 +4,6 @@
             "type": "SelectVariable",
             "caption": "Primary Measuring Point",
             "name": "PrimaryPointID",
-            "width": "700px",
             "requiredLogging": 1
         },
         {

--- a/VirtuelleMessstelle/form.json
+++ b/VirtuelleMessstelle/form.json
@@ -29,8 +29,7 @@
                                 "caption": "Subtract",
                                 "value": 1
                             }
-                        ],
-                        "width": "700px"
+                        ]
                     }
                 },
                 {

--- a/VirtuelleMessstelle/module.php
+++ b/VirtuelleMessstelle/module.php
@@ -146,11 +146,11 @@ class VirtuelleMessstelle extends IPSModule
             $jsonForm['elements'][0]['type'] = 'Select';
             $jsonForm['elements'][0]['options'] = $options;
             $jsonForm['elements'][0]['width'] = '700px';
-            unset($jsonForm['elements'][0]['requireLogging']);
+            unset($jsonForm['elements'][0]['requiredLogging']);
 
             $jsonForm['elements'][1]['columns'][1]['edit']['type'] = 'Select';
             $jsonForm['elements'][1]['columns'][1]['edit']['options'] = $options;
-            unset($jsonForm['elements'][1]['colums'][1]['edit']['requireLogging']);
+            unset($jsonForm['elements'][1]['colums'][1]['edit']['requiredLogging']);
             if (count($options) > 0) {
                 $jsonForm['elements'][1]['columns'][1]['add'] = $options[0]['value'];
             }

--- a/VirtuelleMessstelle/module.php
+++ b/VirtuelleMessstelle/module.php
@@ -145,9 +145,12 @@ class VirtuelleMessstelle extends IPSModule
             $options = $this->GetOptions();
             $jsonForm['elements'][0]['type'] = 'Select';
             $jsonForm['elements'][0]['options'] = $options;
+            $jsonForm['elements'][0]['width'] = '700px';
+            unset($jsonForm['elements'][0]['requireLogging']);
 
             $jsonForm['elements'][1]['columns'][1]['edit']['type'] = 'Select';
             $jsonForm['elements'][1]['columns'][1]['edit']['options'] = $options;
+            unset($jsonForm['elements'][1]['colums'][1]['edit']['requireLogging']);
             if (count($options) > 0) {
                 $jsonForm['elements'][1]['columns'][1]['add'] = $options[0]['value'];
             }

--- a/VirtuelleMessstelle/module.php
+++ b/VirtuelleMessstelle/module.php
@@ -150,6 +150,8 @@ class VirtuelleMessstelle extends IPSModule
 
             $jsonForm['elements'][1]['columns'][1]['edit']['type'] = 'Select';
             $jsonForm['elements'][1]['columns'][1]['edit']['options'] = $options;
+            $jsonForm['elements'][1]['columns'][0]['edit']['width'] = '700px';
+            $jsonForm['elements'][1]['columns'][1]['edit']['width'] = '700px';
             unset($jsonForm['elements'][1]['colums'][1]['edit']['requiredLogging']);
             if (count($options) > 0) {
                 $jsonForm['elements'][1]['columns'][1]['add'] = $options[0]['value'];

--- a/VirtuelleMessstelle/module.php
+++ b/VirtuelleMessstelle/module.php
@@ -139,12 +139,20 @@ class VirtuelleMessstelle extends IPSModule
     {
         //Add options to form
         $jsonForm = json_decode(file_get_contents(__DIR__ . '/form.json'), true);
-        $options = $this->GetOptions();
-        $jsonForm['elements'][0]['options'] = $options;
-        $jsonForm['elements'][1]['columns'][1]['edit']['options'] = $options;
-        if (count($options) > 0) {
-            $jsonForm['elements'][1]['columns'][1]['add'] = $options[0]['value'];
+
+        //If the module "SyncMySQL" is install, get other options
+        if (IPS_ModuleExists('{7E122824-E4D6-4FF8-8AA1-2B7BB36D5EC9}')) {
+            $options = $this->GetOptions();
+            $jsonForm['elements'][0]['type'] = 'Select';
+            $jsonForm['elements'][0]['options'] = $options;
+
+            $jsonForm['elements'][1]['columns'][1]['edit']['type'] = 'Select';
+            $jsonForm['elements'][1]['columns'][1]['edit']['options'] = $options;
+            if (count($options) > 0) {
+                $jsonForm['elements'][1]['columns'][1]['add'] = $options[0]['value'];
+            }
         }
+
         return json_encode($jsonForm);
     }
 


### PR DESCRIPTION
Da der Standard für die Variablenauswahl "SelectVariable" ist wurde das Konfigurationsfeld von "Select" zu "SelectVariable" gewechselt. Um die Funktionalität für den Ursprünglichen Auftraggeber mit dem Modul "SyncMySQL" zu behalten, wird das Feld Select trotzdem angezeigt, wenn das Modul installiert ist. 