### PR TITLE
Synchronisieren von Archivdaten der Messstationen mit dem Ergebnis

### DIFF
--- a/VirtuelleMessstelle/form.json
+++ b/VirtuelleMessstelle/form.json
@@ -1,6 +1,21 @@
 {
     "elements": [
         {
+            "type": "RowLayout",
+            "items": [
+                {
+                    "type": "SelectDate",
+                    "name": "StartDate",
+                    "caption": "Start Date"
+                },
+                {
+                    "type": "Button",
+                    "onClick": "VM_SyncPointsWithResult($id, $StartDate);",
+                    "caption": "Add past values"
+                }
+            ]
+        },
+        {
             "type": "SelectVariable",
             "caption": "Primary Measuring Point",
             "name": "PrimaryPointID",


### PR DESCRIPTION
Es wurde die Möglichkeit hinzugefügt die Messdaten aus dem Archiv ab einem ausgewählten Zeitpunkt bis zum aktuellen Zeitpunkt durch die gleiche Berechnung dem Ergebnis hinzuzufügen.  

close https://github.com/symcon/modules/issues/225