### PR TITLE
Hinzufügen eines Button um negative Werte zurückzusetzen

### DIFF
--- a/VirtuelleMessstelle/form.json
+++ b/VirtuelleMessstelle/form.json
@@ -3,7 +3,7 @@
         {
             "code": 201,
             "icon": "error",
-            "caption": "Multiply update with negative values"
+            "caption": "Multiple updates with negative values"
         }
     ],
     "elements": [
@@ -85,7 +85,7 @@
                 {
                     "type": "Button",
                     "onClick": "VM_ResetLastNegativeValues($id);",
-                    "caption": "Reset negative values"
+                    "caption": "Reset error state"
                 }
             ]
         }

--- a/VirtuelleMessstelle/form.json
+++ b/VirtuelleMessstelle/form.json
@@ -1,4 +1,11 @@
 {
+    "status":[
+        {
+            "code": 201,
+            "icon": "error",
+            "caption": "Multiply update with negative values"
+        }
+    ],
     "elements": [
         {
             "type": "SelectVariable",
@@ -58,6 +65,27 @@
                     "type": "Button",
                     "onClick": "VM_SyncPointsWithResult($id, $StartDate);",
                     "caption": "Add Past Values"
+                }
+            ]
+        },
+        {
+            "type": "RowLayout",
+            "name": "resetLastValues",
+            "visible": "false",
+            "items":[
+                {
+                    "type": "Label",
+                    "caption": "Current negative value: "
+                },
+                {
+                    "type": "Label",
+                    "name": "currentNegativeValue",
+                    "caption": "NAN"
+                },
+                {
+                    "type": "Button",
+                    "onClick": "VM_ResetLastNegativeValues($id);",
+                    "caption": "Reset negative values"
                 }
             ]
         }

--- a/VirtuelleMessstelle/form.json
+++ b/VirtuelleMessstelle/form.json
@@ -1,5 +1,5 @@
 {
-    "status":[
+    "status": [
         {
             "code": 201,
             "icon": "error",
@@ -72,7 +72,7 @@
             "type": "RowLayout",
             "name": "resetLastValues",
             "visible": "false",
-            "items":[
+            "items": [
                 {
                     "type": "Label",
                     "caption": "Current negative value: "

--- a/VirtuelleMessstelle/locale.json
+++ b/VirtuelleMessstelle/locale.json
@@ -10,7 +10,10 @@
             "Result": "Ergebnis",
             "The changes are negative": "Die Änderungen sind negativ",
             "Start Date": "Startdatum",
-            "Add Past Values": "Füge vergangene Werte hinzu"
+            "Add Past Values": "Füge vergangene Werte hinzu",
+            "Current negative value: ": "Momentaner negativer Wert",
+            "Reset negative values": "Zurücksetzen des negativen Wertes",
+            "Multiply update with negative values": "Mehrfache Updates mit negativen Wert"
         }
     }
 }

--- a/VirtuelleMessstelle/locale.json
+++ b/VirtuelleMessstelle/locale.json
@@ -8,12 +8,11 @@
             "Add": "Addieren",
             "Subtract": "Subtrahieren",
             "Result": "Ergebnis",
-            "The changes are negative": "Die Änderungen sind negativ",
             "Start Date": "Startdatum",
             "Add Past Values": "Füge vergangene Werte hinzu",
             "Current negative value: ": "Momentaner negativer Wert",
-            "Reset negative values": "Zurücksetzen des negativen Wertes",
-            "Multiply update with negative values": "Mehrfache Updates mit negativen Wert"
+            "Reset error state": "Fehlerzustand zurücksetzen",
+            "Multiple updates with negative values": "Mehrfache Updates mit negativen Wert"
         }
     }
 }


### PR DESCRIPTION
Wenn öfter als 10 mal hintereinander ein negativer Wert auftaucht, wird ein die Instanz als fehlerhaft gekennzeichnet und im Konfigurationsformular wird im Aktionsbereich ein Button sichtbar mit dem die negativen Werte zurückgesetzt werden.

close https://github.com/symcon/modules/issues/232